### PR TITLE
[Authorization] Changed to using can?/2 for actions that do not perta…

### DIFF
--- a/lib/tradewinds/abilities/event.ex
+++ b/lib/tradewinds/abilities/event.ex
@@ -11,22 +11,16 @@ defmodule Tradewinds.Events.Event.Abilities do
   @access_permissions [:create, :list]
   @instance_permissions [:read, :write, :delete]
 
-  def can?(%User{id: user_id,  permissions: perms}, action, %Event{admins: admins}) do
+  def can?(%User{id: user_id,  permissions: perms}, action, %Event{admins: admins}) when action in @instance_permissions do
     cond do
       perm?(perms, :event, action) -> approved()
-      admins == nil -> no_access_permission()
-      Enum.member?(admins, user_id) ->
-        if Enum.member?(@instance_permissions, action) do
-          approved()
-        else
-          invalid_request("Event", action)
-        end
-      Enum.member?(@access_permissions, action) -> no_access_permission()
-      Enum.member?(@instance_permissions, action) -> no_instance_permission()
+      admins == nil -> no_instance_permission()
+      Enum.member?(admins, user_id) -> approved()
+      true -> no_instance_permission()
     end
   end
 
-  def can?(%User{permissions: perms}, action, Event) do
+  def can?(%User{permissions: perms}, action) when action in @access_permissions do
     if perm?(perms, :event, action) do
       approved()
     else

--- a/lib/tradewinds/abilities/trail.ex
+++ b/lib/tradewinds/abilities/trail.ex
@@ -10,37 +10,30 @@ defmodule Tradewinds.Trails.Trail.Abilities do
 
   @cannot_change_history {:error, "Historic records are not editable"}
   @permissions [:read, :write, :list, :delete, :create]
+  @historically_pertinent_actions [:write, :delete]
 
-  def can?(%User{id: user_id, permissions: perms}, :delete, %Trail{owners: owners, start: start})  do
+  def can?(%User{id: user_id, permissions: perms}, action, %Trail{owners: owners, start: start}) when action in @historically_pertinent_actions do
     cond do
       historical?(start) -> @cannot_change_history
       Enum.member?(owners, user_id) -> approved()
-      perm?(perms, :trail, :delete) -> approved()
+      perm?(perms, :trail, action) -> approved()
       true -> no_instance_permission()
     end
   end
 
-  def can?(%User{id: user_id, permissions: perms}, :write, %Trail{start: start, owners: owners}) do
-    cond do
-      historical?(start) -> @cannot_change_history
-      Enum.member?(owners, user_id) -> approved()
-      perm?(perms, :trail, :write) -> approved()
-      true -> no_instance_permission()
-    end
+  def can?(%User{}, :read, %Trail{}) do
+    approved()
   end
 
-  def can?(%User{permissions: perms}, :create, _) do
+  def can?(%User{permissions: perms}, :create) do
     case perm?(perms, :trail, :create) do
       true -> approved()
       false -> no_access_permission()
     end
   end
 
-  def can?(%User{}, action, _) do
-    case Enum.member?(@permissions, action) do
-      true -> approved()
-      false -> no_access_permission()
-    end
+  def can?(%User{}, :list) do
+    approved()
   end
 
   def permissions do

--- a/lib/tradewinds/abilities/user.ex
+++ b/lib/tradewinds/abilities/user.ex
@@ -8,12 +8,8 @@ defmodule Tradewinds.Accounts.User.Abilities do
 
   require Logger
 
-  @allowed_self_actions [:read, :write]
   @no_instance_permission {:error, "Current user does not have permission to perform this action on this user."}
-  @no_access_permission {:error, "Current user does not have permission to access this content"}
   @cannot_delete_self {:error, "You cannot delete yourself"}
-  @approved {:ok, true}
-  @no_self_permission {:error, "User cannot perform this action on themselves"}
   @permissions [:list, :read, :write, :create, :delete]
   @access_perms [:list, :create]
   @instance_perms [:read, :write, :delete]
@@ -21,27 +17,23 @@ defmodule Tradewinds.Accounts.User.Abilities do
   def can?(%User{id: current_user_id, permissions: perms}, :delete, %User{id: user_id}) do
     cond do
       current_user_id == user_id -> @cannot_delete_self
-      perm?(perms, :user, :delete) -> @approved
+      perm?(perms, :user, :delete) -> approved()
       true -> @no_instance_permission
-    end
-  end
-
-  def can?(%User{permissions: perms}, action, User) when action in @access_perms do
-    case perm?(perms, :user, action) do
-      true -> @approved
-      false -> @no_access_permission
     end
   end
 
   def can?(%User{id: current_user_id, permissions: perms}, action, %User{id: user_id}) when action in @instance_perms do
     cond do
-      current_user_id == user_id ->
-        case Enum.member?(@allowed_self_actions, action) do
-          true -> @approved
-          false -> @no_self_permission
-        end
-      perm?(perms, :user, action) -> @approved
+      current_user_id == user_id -> approved()
+      perm?(perms, :user, action) -> approved()
       true -> @no_instance_permission
+    end
+  end
+
+  def can?(%User{permissions: perms}, action) when action in @access_perms do
+    case perm?(perms, :user, action) do
+      true -> approved()
+      false -> no_access_permission()
     end
   end
 

--- a/lib/tradewinds_web/controllers/event_controller.ex
+++ b/lib/tradewinds_web/controllers/event_controller.ex
@@ -8,7 +8,7 @@ defmodule TradewindsWeb.EventController do
   plug Tradewinds.Plug.Secure
 
   def index(conn, _params) do
-    case conn.assigns.current_user |> can?(:list, Event) do
+    case conn.assigns.current_user |> can?(:list) do
       {:ok, true} ->
         events = Events.list_events()
         render(conn, "index.html", events: events)
@@ -20,7 +20,7 @@ defmodule TradewindsWeb.EventController do
   end
 
   def new(conn, _params) do
-    case conn.assigns.current_user |> can?(:create, Event) do
+    case conn.assigns.current_user |> can?(:create) do
       {:ok, true} ->
         changeset = Events.change_event(%Event{})
         render(conn, "new.html", changeset: changeset)
@@ -32,7 +32,7 @@ defmodule TradewindsWeb.EventController do
   end
 
   def create(conn, %{"event" => event_params}) do
-    case conn.assigns.current_user |> can?(:create, Event) do
+    case conn.assigns.current_user |> can?(:create) do
       {:ok, true} ->
         case Events.create_event(event_params) do
           {:ok, event} ->

--- a/lib/tradewinds_web/controllers/trail_controller.ex
+++ b/lib/tradewinds_web/controllers/trail_controller.ex
@@ -8,7 +8,7 @@ defmodule TradewindsWeb.TrailController do
   plug Tradewinds.Plug.Secure
 
   def index(conn, _params) do
-    case conn.assigns.current_user |> can?(:list, Trail) do
+    case conn.assigns.current_user |> can?(:list) do
       {:ok, true} ->
         trails = Trails.list_trails()
         render(conn, "index.html", trails: trails)
@@ -20,7 +20,7 @@ defmodule TradewindsWeb.TrailController do
   end
 
   def new(conn, _params) do
-    case conn.assigns.current_user |> can?(:create, Trail) do
+    case conn.assigns.current_user |> can?(:create) do
       {:ok, true} ->
         changeset = Trails.change_trail(%Trail{})
         render(conn, "new.html", changeset: changeset)
@@ -32,7 +32,7 @@ defmodule TradewindsWeb.TrailController do
   end
 
   def create(conn, %{"trail" => trail_params}) do
-    case conn.assigns.current_user |> can?(:create, Trail) do
+    case conn.assigns.current_user |> can?(:create) do
       {:ok, true} ->
         trail_params
         |> Map.put_new("creator", conn.assigns.current_user.id)

--- a/lib/tradewinds_web/controllers/user_controller.ex
+++ b/lib/tradewinds_web/controllers/user_controller.ex
@@ -9,7 +9,7 @@ defmodule TradewindsWeb.UserController do
   plug Tradewinds.Plug.Secure
 
   def index(conn, _params) do
-    case conn.assigns.current_user |> can?(:list, User) do
+    case conn.assigns.current_user |> can?(:list) do
       {:ok, true} ->
         users = Accounts.list_users()
         render(conn, "index.html", users: users)
@@ -21,7 +21,7 @@ defmodule TradewindsWeb.UserController do
   end
 
   def new(conn, _params) do
-    case conn.assigns.current_user |> can?(:create, User) do
+    case conn.assigns.current_user |> can?(:create) do
       {:ok, true} ->
         changeset = Accounts.change_user(%User{})
         render(conn, "new.html", changeset: changeset)
@@ -33,7 +33,7 @@ defmodule TradewindsWeb.UserController do
   end
 
   def create(conn, %{"user" => user_params}) do
-    case conn.assigns.current_user |> can?(:create, User) do
+    case conn.assigns.current_user |> can?(:create) do
       {:ok, true} ->
         case Accounts.create_user(user_params) do
           {:ok, user} ->

--- a/test/tradewinds/abilities/event_test.exs
+++ b/test/tradewinds/abilities/event_test.exs
@@ -19,12 +19,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -43,12 +43,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -67,12 +67,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Common.approved() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -91,12 +91,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, event)
     end
 
-    test "can list events", %{user: user, event: event} do
-      assert Common.approved() == Abilities.can?(user, :list, event)
+    test "can list events", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -115,12 +115,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :list)
     end
 
-    test "can create events", %{user: user, event: event} do
-      assert Common.approved() == Abilities.can?(user, :create, event)
+    test "can create events", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :create)
     end
   end
 
@@ -139,12 +139,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -163,12 +163,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -187,12 +187,12 @@ defmodule Tradewinds.Abilities.EventsTest do
       assert Common.approved() == Abilities.can?(user, :delete, event)
     end
 
-    test "cannot list events", %{user: user, event: event} do
-      assert Common.invalid_request("Event", :list) == Abilities.can?(user, :list, event)
+    test "cannot list events", %{user: user} do
+      assert Common.no_access_permission == Abilities.can?(user, :list)
     end
 
-    test "cannot create events", %{user: user, event: event} do
-      assert Common.invalid_request("Event", :create) == Abilities.can?(user, :create, event)
+    test "cannot create events", %{user: user} do
+      assert Common.no_access_permission == Abilities.can?(user, :create)
     end
   end
 

--- a/test/tradewinds/abilities/trail_test.exs
+++ b/test/tradewinds/abilities/trail_test.exs
@@ -35,12 +35,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create trails", %{user: user, trail: trail} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, trail)
+    test "cannot create trails", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -59,12 +59,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create trails", %{user: user, trail: trail} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, trail)
+    test "cannot create trails", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -83,12 +83,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "can create trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :create, trail)
+    test "can create trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :create)
     end
   end
 
@@ -107,12 +107,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Common.approved() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create trails", %{user: user, trail: trail} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, trail)
+    test "cannot create trails", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -131,12 +131,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create trails", %{user: user, trail: trail} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, trail)
+    test "cannot create trails", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -155,12 +155,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create trails", %{user: user, trail: trail} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, trail)
+    test "cannot create trails", %{user: user} do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 
@@ -179,12 +179,12 @@ defmodule Tradewinds.Abilities.TrailsTest do
       assert Abilities.no_instance_permission() == Abilities.can?(user, :delete, trail)
     end
 
-    test "can list trails", %{user: user, trail: trail} do
-      assert Common.approved() == Abilities.can?(user, :list, trail)
+    test "can list trails", %{user: user} do
+      assert Common.approved() == Abilities.can?(user, :list)
     end
 
-    test "cannot create trails", %{user: user, trail: trail} do
-      assert Common.no_access_permission() == Abilities.can?(user, :create, trail)
+    test "cannot create trails", %{user: user } do
+      assert Common.no_access_permission() == Abilities.can?(user, :create)
     end
   end
 end

--- a/test/tradewinds/abilities/user_test.exs
+++ b/test/tradewinds/abilities/user_test.exs
@@ -26,11 +26,11 @@ defmodule Tradewinds.Abilities.UserTest do
     end
 
     test "cannot list users", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :list, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :list)
     end
 
     test "cannot create a user", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :create, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :create)
     end
   end
 
@@ -54,11 +54,11 @@ defmodule Tradewinds.Abilities.UserTest do
     end
 
     test "cannot list users", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :list, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :list)
     end
 
     test "cannot create a user", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :create, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :create)
     end
   end
 
@@ -82,11 +82,11 @@ defmodule Tradewinds.Abilities.UserTest do
     end
 
     test "cannot list users", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :list, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :list)
     end
 
     test "cannot create a user", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :create, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :create)
     end
   end
 
@@ -110,11 +110,11 @@ defmodule Tradewinds.Abilities.UserTest do
     end
 
     test "can list users", %{current_user: current} do
-      assert Common.approved() == Abilities.can?(current, :list, User)
+      assert Common.approved() == Abilities.can?(current, :list)
     end
 
     test "cannot create a user", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :create, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :create)
     end
   end
 
@@ -138,11 +138,11 @@ defmodule Tradewinds.Abilities.UserTest do
     end
 
     test "cannot list users", %{current_user: current} do
-      assert Common.no_access_permission() == Abilities.can?(current, :list, User)
+      assert Common.no_access_permission() == Abilities.can?(current, :list)
     end
 
     test "can create a user", %{current_user: current} do
-      assert Common.approved() == Abilities.can?(current, :create, User)
+      assert Common.approved() == Abilities.can?(current, :create)
     end
   end
 

--- a/tradewinds.iml
+++ b/tradewinds.iml
@@ -7,5 +7,61 @@
     </content>
     <orderEntry type="jdk" jdkName="Unknown Elixir version at /Users/nate/.asdf/installs/elixir/1.9.4" jdkType="Elixir SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="phoenix" level="project" />
+    <orderEntry type="library" name="phoenix_pubsub" level="project" />
+    <orderEntry type="library" name="phoenix_ecto" level="project" />
+    <orderEntry type="library" name="ecto_sql" level="project" />
+    <orderEntry type="library" name="postgrex" level="project" />
+    <orderEntry type="library" name="phoenix_html" level="project" />
+    <orderEntry type="library" name="phoenix_live_reload" level="project" />
+    <orderEntry type="library" name="gettext" level="project" />
+    <orderEntry type="library" name="jason" level="project" />
+    <orderEntry type="library" name="plug_cowboy" level="project" />
+    <orderEntry type="library" name="ueberauth" level="project" />
+    <orderEntry type="library" name="ueberauth_auth0" level="project" />
+    <orderEntry type="library" name="poison" level="project" />
+    <orderEntry type="library" name="auth0_ex" level="project" />
+    <orderEntry type="library" name="httpoison" level="project" />
+    <orderEntry type="library" name="navigation_history" level="project" />
+    <orderEntry type="library" name="credo" level="project" />
+    <orderEntry type="library" name="ex_doc" level="project" />
+    <orderEntry type="library" name="plug" level="project" />
+    <orderEntry type="library" name="telemetry" level="project" />
+    <orderEntry type="library" name="inch_ex" level="project" />
+    <orderEntry type="library" name="websocket_client" level="project" />
+    <orderEntry type="library" name="dialyze" level="project" />
+    <orderEntry type="library" name="ecto" level="project" />
+    <orderEntry type="library" name="db_connection" level="project" />
+    <orderEntry type="library" name="benchee" level="project" />
+    <orderEntry type="library" name="benchee_json" level="project" />
+    <orderEntry type="library" name="decimal" level="project" />
+    <orderEntry type="library" name="connection" level="project" />
+    <orderEntry type="library" name="earmark" level="project" />
+    <orderEntry type="library" name="file_system" level="project" />
+    <orderEntry type="library" name="cowboy" level="project" />
+    <orderEntry type="library" name="hackney" level="project" />
+    <orderEntry type="library" name="kadabra" level="project" />
+    <orderEntry type="library" name="x509" level="project" />
+    <orderEntry type="library" name="dialyxir" level="project" />
+    <orderEntry type="library" name="excoveralls" level="project" />
+    <orderEntry type="library" name="oauth2" level="project" />
+    <orderEntry type="library" name="exvcr" level="project" />
+    <orderEntry type="library" name="benchee_html" level="project" />
+    <orderEntry type="library" name="exjsx" level="project" />
+    <orderEntry type="library" name="tiny" level="project" />
+    <orderEntry type="library" name="jsone" level="project" />
+    <orderEntry type="library" name="jiffy" level="project" />
+    <orderEntry type="library" name="json" level="project" />
+    <orderEntry type="library" name="httparrot" level="project" />
+    <orderEntry type="library" name="meck" level="project" />
+    <orderEntry type="library" name="bunt" level="project" />
+    <orderEntry type="library" name="makeup_elixir" level="project" />
+    <orderEntry type="library" name="cmark" level="project" />
+    <orderEntry type="library" name="mime" level="project" />
+    <orderEntry type="library" name="plug_crypto" level="project" />
+    <orderEntry type="library" name="bypass" level="project" />
+    <orderEntry type="library" name="makeup" level="project" />
+    <orderEntry type="library" name="nimble_parsec" level="project" />
+    <orderEntry type="library" name="stream_data" level="project" />
   </component>
 </module>


### PR DESCRIPTION
…in to an instance.

Combining this change with guard clauses, it allows for the logic of action relevance to be moved out of code and enforced by language idioms.